### PR TITLE
即座に指定のページに切り替える手段を追加

### DIFF
--- a/Classes/CAPSPageMenu.swift
+++ b/Classes/CAPSPageMenu.swift
@@ -1115,4 +1115,22 @@ open class CAPSPageMenu: UIViewController, UIScrollViewDelegate, UIGestureRecogn
             })
         }
     }
+
+    open func setPage(_ index: Int) {
+        guard index != currentPageIndex && controllerArray.indices.contains(index) else {
+            return
+        }
+
+        startingPageForScroll = index
+        lastPageIndex = currentPageIndex
+        currentPageIndex = index
+
+        addPageAtIndex(index)
+
+        let xOffset = CGFloat(index) * controllerScrollView.frame.width
+        let offset = CGPoint(x: xOffset, y: controllerScrollView.contentOffset.y)
+        controllerScrollView.setContentOffset(offset, animated: false)
+
+        removePageAtIndex(lastPageIndex)
+    }
 }


### PR DESCRIPTION
## 説明

- `moveToPage` は以下の点が辛い
    - ページメニュータップ時の処理をコピペしたのか、妙な挙動になっている
        - メニュータップによるスクロール開始フラグを立てているが、下げる処理がない
    - 現在位置から移動さきまでに登録されている ViewController が全てロードされる
- これらの問題が起こらないような、初期位置変更用に使えるページ切り替えメソッドを追加した